### PR TITLE
exclude node modules

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -22,6 +22,7 @@ class Factory
             ->in($projectRoot)
             ->exclude([
                 'bootstrap/cache',
+                'node_modules',
                 'storage',
             ])
             ->notPath([


### PR DESCRIPTION
I bumped into this updating our project standard. Apparently there's a PHP file somewhere in node_modules and it got scanned. We should exclude it even if there aren't PHP files in there too.